### PR TITLE
Adds support for SQL Server Data Tools (SSDT) snippets

### DIFF
--- a/src/SnippetDesigner/LanguageMaps.cs
+++ b/src/SnippetDesigner/LanguageMaps.cs
@@ -11,6 +11,7 @@ namespace Microsoft.SnippetDesigner
         XML,
         JavaScript,
         SQL,
+        SQLServerDataTools,
         HTML, 
         XAML
     }
@@ -59,6 +60,8 @@ namespace Microsoft.SnippetDesigner
                     return Resources.DisplayNameJavaScript;
                 case Language.SQL:
                     return Resources.DisplayNameSQL;
+                case Language.SQLServerDataTools:
+                    return Resources.DisplayNameSQLServerDataTools;
                 case Language.HTML:
                     return Resources.DisplayNameHTML;
                 case Language.XAML:
@@ -91,6 +94,8 @@ namespace Microsoft.SnippetDesigner
                                : StringConstants.SchemaNameJavaScriptVS11;
                 case Language.SQL:
                     return StringConstants.SchemaNameSQL;
+                case Language.SQLServerDataTools:
+                    return StringConstants.SchemaNameSQLServerDataTools;
                 case Language.HTML:
                     return StringConstants.SchemaNameHTML;
                 case Language.XAML:
@@ -122,6 +127,7 @@ namespace Microsoft.SnippetDesigner
             snippetSchemaLanguageToDisplay[StringConstants.SchemaNameJavaScript] = Resources.DisplayNameJavaScript;
             snippetSchemaLanguageToDisplay[StringConstants.SchemaNameJavaScriptVS11] = Resources.DisplayNameJavaScript;
             snippetSchemaLanguageToDisplay[StringConstants.SchemaNameSQL] = Resources.DisplayNameSQL;
+            snippetSchemaLanguageToDisplay[StringConstants.SchemaNameSQLServerDataTools] = Resources.DisplayNameSQLServerDataTools;
             snippetSchemaLanguageToDisplay[StringConstants.SchemaNameHTML] = Resources.DisplayNameHTML;
 
 
@@ -146,6 +152,7 @@ namespace Microsoft.SnippetDesigner
                                                                         ? StringConstants.SchemaNameJavaScript
                                                                         : StringConstants.SchemaNameJavaScriptVS11;
             displayLanguageToXML[Resources.DisplayNameSQL] = StringConstants.SchemaNameSQL;
+            displayLanguageToXML[Resources.DisplayNameSQLServerDataTools] = StringConstants.SchemaNameSQLServerDataTools;
             displayLanguageToXML[Resources.DisplayNameHTML] = StringConstants.SchemaNameHTML;
 
             displayLanguageToXML[String.Empty] = String.Empty;

--- a/src/SnippetDesigner/Resources.Designer.cs
+++ b/src/SnippetDesigner/Resources.Designer.cs
@@ -133,6 +133,15 @@ namespace Microsoft.SnippetDesigner {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Microsoft SQL Server Data Tools, T-SQL Language Services.
+        /// </summary>
+        internal static string DisplayNameSQLServerDataTools {
+            get {
+                return ResourceManager.GetString("DisplayNameSQLServerDataTools", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Visual Basic.
         /// </summary>
         internal static string DisplayNameVisualBasic {

--- a/src/SnippetDesigner/Resources.resx
+++ b/src/SnippetDesigner/Resources.resx
@@ -361,4 +361,7 @@
   <data name="DisplayNameXAML" xml:space="preserve">
     <value>XAML</value>
   </data>
+  <data name="DisplayNameSQLServerDataTools" xml:space="preserve">
+    <value>Microsoft SQL Server Data Tools, T-SQL Language Services</value>
+  </data>
 </root>

--- a/src/SnippetDesigner/SnippetDirectories.cs
+++ b/src/SnippetDesigner/SnippetDirectories.cs
@@ -254,6 +254,7 @@ namespace Microsoft.SnippetDesigner
             userSnippetDirectories[Resources.DisplayNameVisualBasic] = Path.Combine(snippetDir, Path.Combine(StringConstants.SnippetDirNameVisualBasic, StringConstants.MySnippetsDir));
             userSnippetDirectories[Resources.DisplayNameXML] = Path.Combine(snippetDir, Path.Combine(StringConstants.SnippetDirNameXML, StringConstants.MyXmlSnippetsDir));
             userSnippetDirectories[Resources.DisplayNameSQL] = Path.Combine(snippetDir, Path.Combine(StringConstants.SnippetDirNameSQL, StringConstants.MySnippetsDir));
+            userSnippetDirectories[Resources.DisplayNameSQLServerDataTools] = Path.Combine(snippetDir, Path.Combine(StringConstants.SnippetDirNameSQLServerDataTools, StringConstants.MySnippetsDir));
 
             if (!SnippetDesignerPackage.Instance.IsVisualStudio2010)
             {

--- a/src/SnippetDesigner/StringConstants.cs
+++ b/src/SnippetDesigner/StringConstants.cs
@@ -48,6 +48,7 @@ namespace Microsoft.SnippetDesigner
         public const string SchemaNameJavaScript = "jscript";
         public const string SchemaNameJavaScriptVS11 = "javascript";
         public const string SchemaNameSQL = "sql";
+        public const string SchemaNameSQLServerDataTools = "SQL_SSDT";
         public const string SchemaNameHTML = "html";
         public const string SchemaNameXAML = "xaml";
 
@@ -57,6 +58,7 @@ namespace Microsoft.SnippetDesigner
         public const string SnippetDirNameVisualBasic = "Visual Basic";
         public const string SnippetDirNameXML = "XML";
         public const string SnippetDirNameSQL = "SQL_SSDT";
+        public const string SnippetDirNameSQLServerDataTools = "SQL_SSDT";
         public const string SnippetDirNameHTML = "My HTML Snippets";
         public const string SnippetDirNameJavaScript = "My JScript Snippets";
         public const string SnippetDirNameJavaScriptVS11 = "JavaScript";


### PR DESCRIPTION
As stated in #112, when you have SQL Server Data Tools installed (which many VS 2015 users must have), VS transforms the SQL Snippets into SQL Server Data Tools (SSDT) snippets.

This makes it possible to create snippets for SSDT correctly.